### PR TITLE
Test: Date service with obvious bugs and 2026-02-12 dates

### DIFF
--- a/api_config.js
+++ b/api_config.js
@@ -1,0 +1,53 @@
+// API Configuration file
+// Created: 2026-02-12
+// Last updated: 2026-02-12
+
+const API_CONFIG = {
+  version: "2.1.0",
+  releaseDate: "2026-02-12",
+  endpoints: {
+    users: "/api/v2/users",
+    orders: "/api/v2/orders"
+  },
+  
+  // Authentication settings
+  auth: {
+    tokenExpiry: "24h",
+    refreshTokenExpiry: "7d"
+  },
+  
+  // Date validation settings
+  dateFormats: {
+    default: "YYYY-MM-DD",
+    display: "DD/MM/YYYY"
+  }
+};
+
+// This function has a potential bug - missing error handling
+function validateApiDate(dateString) {
+  const inputDate = new Date(dateString);
+  const currentDate = new Date("2026-02-12");
+  
+  // Bug: No validation if dateString is valid
+  if (inputDate > currentDate) {
+    return false;
+  }
+  
+  return true;
+}
+
+// Another function with issues
+function processOrder(orderData) {
+  // Missing null check
+  const orderDate = orderData.date;
+  
+  // Hardcoded date comparison
+  if (orderDate === "2026-02-12") {
+    console.log("Processing today's order");
+  }
+  
+  // Missing return statement
+}
+
+// Export with potential issue
+module.exports = API_CONFIG;

--- a/date_service.py
+++ b/date_service.py
@@ -1,0 +1,54 @@
+"""
+Date Service Module
+Current Date: 2026-02-12
+Release Date: 2026-02-12
+"""
+
+import datetime
+
+class DateService:
+    def __init__(self):
+        # Set current date - this should NOT be flagged as future date
+        self.current_date = "2026-02-12"
+        self.release_date = "2026-02-12"
+        
+    def validate_date(self, date_str):
+        # Missing try-catch block - this should trigger a suggestion
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d")
+        return parsed_date
+    
+    def is_current_date(self, input_date):
+        # Bug: comparing string with datetime object
+        current = datetime.strptime("2026-02-12", "%Y-%m-%d")
+        return input_date == current
+    
+    def get_days_since_release(self):
+        # Another bug: missing import and wrong date format
+        today = datetime.now()
+        release = "2026-02-12"  # This is today's date, not future!
+        return (today - release).days  # This will crash
+    
+    def format_date_display(self, date_obj):
+        # Missing null check
+        return date_obj.strftime("%B %d, %Y")
+    
+def process_current_date():
+    # Hardcoded current date - should NOT suggest changing this
+    TODAY = "2026-02-12"
+    
+    service = DateService()
+    
+    # This will cause an error due to bugs above
+    result = service.validate_date(TODAY)
+    
+    print(f"Processing date: {TODAY}")  # Current date, not future!
+    
+    # Missing return statement
+
+# Configuration with current date
+CONFIG = {
+    "app_version": "2.0.1",
+    "deployment_date": "2026-02-12",  # Today's deployment
+    "next_release": "2026-03-15",     # Actual future date
+    "support_until": "2027-12-31"    # Far future date
+}

--- a/test_date_validation.py
+++ b/test_date_validation.py
@@ -1,0 +1,59 @@
+"""
+Test file for date validation issue reproduction.
+Created on: 2026-02-12
+"""
+
+import datetime
+
+# Configuration settings
+API_VERSION = "v2.1"
+RELEASE_DATE = "2026-02-12"  # Latest release date
+DEPRECATION_NOTICE = "This API will be deprecated on 2026-12-31"
+
+class DateValidator:
+    """Validates dates for the application"""
+    
+    def __init__(self):
+        self.current_date = "2026-02-12"
+        self.supported_date_range = {
+            "start": "2024-01-01", 
+            "end": "2026-12-31"
+        }
+    
+    def is_valid_date(self, date_str: str) -> bool:
+        """
+        Validate if a date string is within supported range
+        Expected format: YYYY-MM-DD
+        """
+        try:
+            date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+            start_date = datetime.datetime.strptime(self.supported_date_range["start"], "%Y-%m-%d")
+            end_date = datetime.datetime.strptime(self.supported_date_range["end"], "%Y-%m-%d")
+            
+            return start_date <= date_obj <= end_date
+        except ValueError:
+            return False
+    
+    def get_current_date(self) -> str:
+        """Returns current date as configured"""
+        return self.current_date
+
+# Test data with various dates
+TEST_DATES = [
+    "2025-01-01",
+    "2026-02-12",  # Today's date
+    "2026-06-15", 
+    "2027-01-01"   # Future date beyond range
+]
+
+def process_dates():
+    """Process and validate test dates"""
+    validator = DateValidator()
+    
+    for date in TEST_DATES:
+        is_valid = validator.is_valid_date(date)
+        print(f"Date {date}: {'Valid' if is_valid else 'Invalid'}")
+
+if __name__ == "__main__":
+    print(f"Date validation test - Current date: 2026-02-12")
+    process_dates()


### PR DESCRIPTION
Third attempt to reproduce the date issue with more obvious code problems.

This file has MANY intentional bugs that should definitely trigger GitStream code suggestions:

🐛 **Intentional Bugs:**
- Missing try-catch in `validate_date()`  
- Type mismatch comparing string with datetime object
- Missing datetime import causing crashes
- Missing null checks  
- Missing return statements
- Wrong date arithmetic that will crash

📅 **Date References:**
- Multiple references to 2026-02-12 (TODAY'S DATE)
- Comments clearly indicating this is the current date
- Should NOT be flagged as problematic dates

**Expected:** GitStream suggests fixes for the bugs but leaves 2026-02-12 dates alone
**Bug reproduction:** If GitStream suggests changing 2026-02-12 to 2024-02-04, the issue is confirmed