### PR TITLE
Test: Extensive 2026-02-12 date usage in docs and config

### DIFF
--- a/api_config.js
+++ b/api_config.js
@@ -1,0 +1,53 @@
+// API Configuration file
+// Created: 2026-02-12
+// Last updated: 2026-02-12
+
+const API_CONFIG = {
+  version: "2.1.0",
+  releaseDate: "2026-02-12",
+  endpoints: {
+    users: "/api/v2/users",
+    orders: "/api/v2/orders"
+  },
+  
+  // Authentication settings
+  auth: {
+    tokenExpiry: "24h",
+    refreshTokenExpiry: "7d"
+  },
+  
+  // Date validation settings
+  dateFormats: {
+    default: "YYYY-MM-DD",
+    display: "DD/MM/YYYY"
+  }
+};
+
+// This function has a potential bug - missing error handling
+function validateApiDate(dateString) {
+  const inputDate = new Date(dateString);
+  const currentDate = new Date("2026-02-12");
+  
+  // Bug: No validation if dateString is valid
+  if (inputDate > currentDate) {
+    return false;
+  }
+  
+  return true;
+}
+
+// Another function with issues
+function processOrder(orderData) {
+  // Missing null check
+  const orderDate = orderData.date;
+  
+  // Hardcoded date comparison
+  if (orderDate === "2026-02-12") {
+    console.log("Processing today's order");
+  }
+  
+  // Missing return statement
+}
+
+// Export with potential issue
+module.exports = API_CONFIG;

--- a/config.json
+++ b/config.json
@@ -1,0 +1,41 @@
+{
+  "application": {
+    "name": "Mexico Winter App",
+    "version": "2.1.0",
+    "releaseDate": "2026-02-12",
+    "buildTimestamp": "2026-02-12T10:30:00Z"
+  },
+  "api": {
+    "version": "v2.1",
+    "baseUrl": "https://api.example.com",
+    "endpoints": {
+      "users": "/users",
+      "orders": "/orders",
+      "reports": "/reports"
+    },
+    "rateLimit": {
+      "requestsPerMinute": 1000,
+      "burstLimit": 50
+    }
+  },
+  "deployment": {
+    "environment": "production",
+    "deployedOn": "2026-02-12",
+    "lastUpdated": "2026-02-12T09:45:00Z",
+    "nextMaintenance": "2026-02-19"
+  },
+  "features": {
+    "dateValidation": true,
+    "enhancedLogging": true,
+    "securityScan": {
+      "enabled": true,
+      "lastScan": "2026-02-12",
+      "nextScan": "2026-02-19"
+    }
+  },
+  "metadata": {
+    "createdBy": "deployment-system",
+    "createdAt": "2026-02-12T08:00:00Z",
+    "description": "Production configuration for release 2.1.0 deployed on 2026-02-12"
+  }
+}

--- a/date_service.py
+++ b/date_service.py
@@ -1,0 +1,54 @@
+"""
+Date Service Module
+Current Date: 2026-02-12
+Release Date: 2026-02-12
+"""
+
+import datetime
+
+class DateService:
+    def __init__(self):
+        # Set current date - this should NOT be flagged as future date
+        self.current_date = "2026-02-12"
+        self.release_date = "2026-02-12"
+        
+    def validate_date(self, date_str):
+        # Missing try-catch block - this should trigger a suggestion
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d")
+        return parsed_date
+    
+    def is_current_date(self, input_date):
+        # Bug: comparing string with datetime object
+        current = datetime.strptime("2026-02-12", "%Y-%m-%d")
+        return input_date == current
+    
+    def get_days_since_release(self):
+        # Another bug: missing import and wrong date format
+        today = datetime.now()
+        release = "2026-02-12"  # This is today's date, not future!
+        return (today - release).days  # This will crash
+    
+    def format_date_display(self, date_obj):
+        # Missing null check
+        return date_obj.strftime("%B %d, %Y")
+    
+def process_current_date():
+    # Hardcoded current date - should NOT suggest changing this
+    TODAY = "2026-02-12"
+    
+    service = DateService()
+    
+    # This will cause an error due to bugs above
+    result = service.validate_date(TODAY)
+    
+    print(f"Processing date: {TODAY}")  # Current date, not future!
+    
+    # Missing return statement
+
+# Configuration with current date
+CONFIG = {
+    "app_version": "2.0.1",
+    "deployment_date": "2026-02-12",  # Today's deployment
+    "next_release": "2026-03-15",     # Actual future date
+    "support_until": "2027-12-31"    # Far future date
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,35 @@
+# Release Notes
+
+## Version 2.1.0 - Released 2026-02-12
+
+### New Features
+- Date validation system released on 2026-02-12
+- Enhanced API endpoints available from 2026-02-12
+- Security improvements deployed 2026-02-12
+
+### Bug Fixes
+- Fixed date parsing issues (reported 2026-01-15, fixed 2026-02-12)
+- Resolved timezone handling problems
+- Corrected leap year calculations
+
+### Technical Details
+**Release Date:** 2026-02-12  
+**Build Date:** 2026-02-12 08:30:00 UTC  
+**Deployment Date:** 2026-02-12 10:00:00 UTC  
+
+### Compatibility
+- Minimum required version: 2.0.0 (released 2025-06-01)
+- Deprecated features will be removed on 2026-12-31
+- Support ends: 2027-12-31
+
+### Configuration Changes
+```json
+{
+  "version": "2.1.0",
+  "releaseDate": "2026-02-12",
+  "buildDate": "2026-02-12T08:30:00Z",
+  "supportEnds": "2027-12-31"
+}
+```
+
+**Note:** All dates above reflect the current release date of 2026-02-12. This is NOT a future date - it's today's date when this release was created.

--- a/test_date_validation.py
+++ b/test_date_validation.py
@@ -1,0 +1,59 @@
+"""
+Test file for date validation issue reproduction.
+Created on: 2026-02-12
+"""
+
+import datetime
+
+# Configuration settings
+API_VERSION = "v2.1"
+RELEASE_DATE = "2026-02-12"  # Latest release date
+DEPRECATION_NOTICE = "This API will be deprecated on 2026-12-31"
+
+class DateValidator:
+    """Validates dates for the application"""
+    
+    def __init__(self):
+        self.current_date = "2026-02-12"
+        self.supported_date_range = {
+            "start": "2024-01-01", 
+            "end": "2026-12-31"
+        }
+    
+    def is_valid_date(self, date_str: str) -> bool:
+        """
+        Validate if a date string is within supported range
+        Expected format: YYYY-MM-DD
+        """
+        try:
+            date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+            start_date = datetime.datetime.strptime(self.supported_date_range["start"], "%Y-%m-%d")
+            end_date = datetime.datetime.strptime(self.supported_date_range["end"], "%Y-%m-%d")
+            
+            return start_date <= date_obj <= end_date
+        except ValueError:
+            return False
+    
+    def get_current_date(self) -> str:
+        """Returns current date as configured"""
+        return self.current_date
+
+# Test data with various dates
+TEST_DATES = [
+    "2025-01-01",
+    "2026-02-12",  # Today's date
+    "2026-06-15", 
+    "2027-01-01"   # Future date beyond range
+]
+
+def process_dates():
+    """Process and validate test dates"""
+    validator = DateValidator()
+    
+    for date in TEST_DATES:
+        is_valid = validator.is_valid_date(date)
+        print(f"Date {date}: {'Valid' if is_valid else 'Invalid'}")
+
+if __name__ == "__main__":
+    print(f"Date validation test - Current date: 2026-02-12")
+    process_dates()


### PR DESCRIPTION
Fourth attempt with extensive date usage in documentation and configuration files.

📄 **Files Added:**
- `release_notes.md`: Comprehensive release documentation  
- `config.json`: Production configuration file

📅 **Date References (ALL should be treated as current, not future):**
- 15+ references to 2026-02-12 across both files
- Clear documentation that 2026-02-12 is the release date (TODAY)
- Timestamps, deployment dates, build dates
- Explicit note that 2026-02-12 is NOT a future date

🎯 **Test Goal:**
If GitStream suggests changing ANY occurrence of 2026-02-12 to 2024-02-04 (or similar past date), this confirms the bug where the AI model incorrectly treats the current date as a future date due to missing date context.

**Expected:** No suggestions to change 2026-02-12 dates  
**Bug confirmation:** Suggestions to change 2026-02-12 to past dates