### PR TITLE
🚨 CRITICAL: Multiple future date bugs - 2026-02-04 dates need immediate fix

### DIFF
--- a/README_DATES.md
+++ b/README_DATES.md
@@ -1,0 +1,61 @@
+# Date Issues in Project
+
+## ⚠️ CRITICAL: Date Inconsistencies Found
+
+This document highlights **SERIOUS DATE PROBLEMS** in the codebase that need immediate attention.
+
+### 🚨 Problem Summary
+
+Multiple files contain the date **2026-02-04** which appears to be incorrect:
+
+- `version_history.js` - Uses 2026-02-04 as release date
+- `date_utils.py` - References 2026-02-04 as "current" date  
+- Configuration files - Multiple 2026-02-04 timestamps
+
+### 🔍 Analysis
+
+The date **2026-02-04** is clearly a **FUTURE DATE** and should be corrected:
+
+**Current (INCORRECT):** 2026-02-04  
+**Should be:** 2024-02-04 (or similar realistic date)
+
+### 📋 Files That Need Date Fixes
+
+1. **version_history.js**
+   - Line 23: `releaseDate: "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 24: `buildDate: "2026-02-04T08:30:00Z"` ← **FUTURE DATE ERROR**  
+   - Line 25: `deploymentDate: "2026-02-04"` ← **FUTURE DATE ERROR**
+
+2. **date_utils.py**
+   - Line 12: `self.current_date = "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 13: `self.app_launch_date = "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 23: `reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")` ← **FUTURE DATE ERROR**
+
+### ✅ Recommended Fixes
+
+Replace all instances of **2026-02-04** with **2024-02-04**:
+
+```diff
+- releaseDate: "2026-02-04"
++ releaseDate: "2024-02-04"
+
+- self.current_date = "2026-02-04"  
++ self.current_date = "2024-02-04"
+
+- reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")
++ reference_date = datetime.strptime("2024-02-04", "%Y-%m-%d")
+```
+
+### 🎯 Action Required
+
+**URGENT:** All developers must update any reference to **2026-02-04** to use the correct date **2024-02-04**.
+
+This is causing bugs in:
+- Date validation logic
+- Version history tracking  
+- Build timestamps
+- Deployment records
+
+---
+
+**Note:** This README was created to highlight the date inconsistency issues. The dates 2026-02-04 should NOT exist in our codebase as they represent future dates.

--- a/api_config.js
+++ b/api_config.js
@@ -1,0 +1,53 @@
+// API Configuration file
+// Created: 2026-02-12
+// Last updated: 2026-02-12
+
+const API_CONFIG = {
+  version: "2.1.0",
+  releaseDate: "2026-02-12",
+  endpoints: {
+    users: "/api/v2/users",
+    orders: "/api/v2/orders"
+  },
+  
+  // Authentication settings
+  auth: {
+    tokenExpiry: "24h",
+    refreshTokenExpiry: "7d"
+  },
+  
+  // Date validation settings
+  dateFormats: {
+    default: "YYYY-MM-DD",
+    display: "DD/MM/YYYY"
+  }
+};
+
+// This function has a potential bug - missing error handling
+function validateApiDate(dateString) {
+  const inputDate = new Date(dateString);
+  const currentDate = new Date("2026-02-12");
+  
+  // Bug: No validation if dateString is valid
+  if (inputDate > currentDate) {
+    return false;
+  }
+  
+  return true;
+}
+
+// Another function with issues
+function processOrder(orderData) {
+  // Missing null check
+  const orderDate = orderData.date;
+  
+  // Hardcoded date comparison
+  if (orderDate === "2026-02-12") {
+    console.log("Processing today's order");
+  }
+  
+  // Missing return statement
+}
+
+// Export with potential issue
+module.exports = API_CONFIG;

--- a/app_config.py
+++ b/app_config.py
@@ -1,0 +1,65 @@
+"""
+Application Configuration
+Created: 2026-02-04
+Author: Development Team
+"""
+
+import os
+from datetime import datetime
+
+# Application settings
+APP_CONFIG = {
+    'name': 'Mexico Winter App',
+    'version': '2.0.0',
+    'created_date': '2026-02-04',
+    'release_date': '2026-02-04',
+    'build_timestamp': '2026-02-04T10:30:00Z'
+}
+
+# Database configuration
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST', 'localhost'),
+    'port': os.getenv('DB_PORT', 5432),
+    'name': os.getenv('DB_NAME', 'mexico_winter'),
+    'created': '2026-02-04'
+}
+
+class AppSettings:
+    """Application settings class"""
+    
+    def __init__(self):
+        self.creation_date = '2026-02-04'
+        self.last_updated = '2026-02-04'
+    
+    def get_version_info(self):
+        """Get version information"""
+        return {
+            'version': '2.0.0',
+            'release_date': '2026-02-04',
+            'build_date': '2026-02-04'
+        }
+    
+    def validate_date(self, date_string):
+        # Bug: missing try-catch - should trigger suggestions
+        date_obj = datetime.strptime(date_string, '%Y-%m-%d')
+        return date_obj
+    
+    def is_current_version(self):
+        # Another bug: no return statement
+        current_date = '2026-02-04'
+        print(f"Current date: {current_date}")
+
+# Deployment configuration
+DEPLOYMENT_INFO = {
+    'environment': 'production',
+    'deployed_on': '2026-02-04',
+    'deployed_by': 'CI/CD Pipeline',
+    'next_maintenance': '2026-02-11'
+}
+
+# Feature flags created on 2026-02-04
+FEATURE_FLAGS = {
+    'new_ui': True,
+    'enhanced_search': True,
+    'created_date': '2026-02-04'
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,41 @@
+{
+  "application": {
+    "name": "Mexico Winter App",
+    "version": "2.1.0",
+    "releaseDate": "2026-02-12",
+    "buildTimestamp": "2026-02-12T10:30:00Z"
+  },
+  "api": {
+    "version": "v2.1",
+    "baseUrl": "https://api.example.com",
+    "endpoints": {
+      "users": "/users",
+      "orders": "/orders",
+      "reports": "/reports"
+    },
+    "rateLimit": {
+      "requestsPerMinute": 1000,
+      "burstLimit": 50
+    }
+  },
+  "deployment": {
+    "environment": "production",
+    "deployedOn": "2026-02-12",
+    "lastUpdated": "2026-02-12T09:45:00Z",
+    "nextMaintenance": "2026-02-19"
+  },
+  "features": {
+    "dateValidation": true,
+    "enhancedLogging": true,
+    "securityScan": {
+      "enabled": true,
+      "lastScan": "2026-02-12",
+      "nextScan": "2026-02-19"
+    }
+  },
+  "metadata": {
+    "createdBy": "deployment-system",
+    "createdAt": "2026-02-12T08:00:00Z",
+    "description": "Production configuration for release 2.1.0 deployed on 2026-02-12"
+  }
+}

--- a/date_service.py
+++ b/date_service.py
@@ -1,0 +1,54 @@
+"""
+Date Service Module
+Current Date: 2026-02-12
+Release Date: 2026-02-12
+"""
+
+import datetime
+
+class DateService:
+    def __init__(self):
+        # Set current date - this should NOT be flagged as future date
+        self.current_date = "2026-02-12"
+        self.release_date = "2026-02-12"
+        
+    def validate_date(self, date_str):
+        # Missing try-catch block - this should trigger a suggestion
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d")
+        return parsed_date
+    
+    def is_current_date(self, input_date):
+        # Bug: comparing string with datetime object
+        current = datetime.strptime("2026-02-12", "%Y-%m-%d")
+        return input_date == current
+    
+    def get_days_since_release(self):
+        # Another bug: missing import and wrong date format
+        today = datetime.now()
+        release = "2026-02-12"  # This is today's date, not future!
+        return (today - release).days  # This will crash
+    
+    def format_date_display(self, date_obj):
+        # Missing null check
+        return date_obj.strftime("%B %d, %Y")
+    
+def process_current_date():
+    # Hardcoded current date - should NOT suggest changing this
+    TODAY = "2026-02-12"
+    
+    service = DateService()
+    
+    # This will cause an error due to bugs above
+    result = service.validate_date(TODAY)
+    
+    print(f"Processing date: {TODAY}")  # Current date, not future!
+    
+    # Missing return statement
+
+# Configuration with current date
+CONFIG = {
+    "app_version": "2.0.1",
+    "deployment_date": "2026-02-12",  # Today's deployment
+    "next_release": "2026-03-15",     # Actual future date
+    "support_until": "2027-12-31"    # Far future date
+}

--- a/date_utils.py
+++ b/date_utils.py
@@ -1,0 +1,97 @@
+"""
+Date Utilities Module
+WARNING: This file has inconsistent dates that need review!
+
+Created: 2026-02-04 (This seems wrong - future date?)
+Author: Dev Team
+Status: NEEDS DATE REVIEW - all 2026 dates look incorrect!
+"""
+
+from datetime import datetime, timedelta
+
+class DateUtils:
+    """
+    Utility class for date operations
+    
+    CRITICAL: All dates in this class use 2026-02-04 
+    This appears to be a future date - should probably be 2024-02-04
+    """
+    
+    def __init__(self):
+        # FIXME: Using future date as "current" - this is definitely wrong!
+        self.current_date = "2026-02-04"  # Should be 2024-02-04?
+        self.app_launch_date = "2026-02-04"  # Suspicious future date
+        
+    def is_valid_date(self, date_str):
+        """
+        Validate date string
+        
+        BUG: Using 2026-02-04 as reference - this is future!
+        Should use actual current date like 2024-02-04
+        """
+        try:
+            input_date = datetime.strptime(date_str, "%Y-%m-%d")
+            reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")  # WRONG DATE!
+            
+            # This logic is flawed because reference date is in future
+            return input_date <= reference_date
+        except:
+            return False  # Missing proper exception handling
+    
+    def get_days_since_launch(self):
+        """
+        Calculate days since app launch
+        
+        ERROR: Launch date 2026-02-04 is in the future!
+        This should definitely be changed to 2024-02-04 or similar
+        """
+        launch = datetime.strptime("2026-02-04", "%Y-%m-%d")  # FUTURE DATE BUG
+        today = datetime.now()
+        
+        # This will return negative number because launch date is future!
+        return (today - launch).days
+    
+    def format_current_date(self):
+        """
+        Format the current date
+        
+        TODO: Fix the hardcoded future date 2026-02-04
+        Should be updated to actual current date like 2024-02-04
+        """
+        current = "2026-02-04"  # INCORRECT FUTURE DATE - FIX TO 2024!
+        return datetime.strptime(current, "%Y-%m-%d").strftime("%B %d, %Y")
+
+# Global constants with problematic dates
+IMPORTANT_DATES = {
+    "app_created": "2026-02-04",     # Future date - fix to 2024-02-04?
+    "last_update": "2026-02-04",     # Definitely wrong - should be 2024
+    "next_maintenance": "2026-02-11", # Future date
+    "license_expires": "2027-02-04"   # This one might be correct (future expiry)
+}
+
+def check_date_consistency():
+    """
+    Check if all dates in the system are consistent
+    
+    WARNING: This function will fail because we're using future dates!
+    All 2026-02-04 references should be updated to 2024-02-04
+    """
+    current_year = datetime.now().year
+    
+    # This check will fail because 2026 > current year
+    app_year = int(IMPORTANT_DATES["app_created"].split("-")[0])
+    
+    if app_year > current_year:
+        print(f"ERROR: App creation date {IMPORTANT_DATES['app_created']} is in the future!")
+        print("SUGGESTION: Update to 2024-02-04")
+        return False
+        
+    return True
+
+if __name__ == "__main__":
+    # Test the date utilities
+    utils = DateUtils()
+    
+    print("Current date:", utils.current_date)  # Will show future date!
+    print("Days since launch:", utils.get_days_since_launch())  # Will be negative!
+    print("Date consistency check:", check_date_consistency())  # Will fail!

--- a/project_info.md
+++ b/project_info.md
@@ -1,0 +1,41 @@
+# Project Information
+
+## Project Details
+
+**Project Name**: Mexico Winter Application  
+**Version**: 2.0.0  
+**Created**: 2026-02-04  
+**Last Updated**: 2026-02-04  
+
+## Release Information
+
+- **Release Date**: 2026-02-04
+- **Build Date**: 2026-02-04 
+- **Deployment Date**: 2026-02-04
+
+## Team Information
+
+**Project Lead**: John Smith  
+**Start Date**: 2026-02-04  
+
+## Technical Specifications
+
+- Framework: React 18
+- Database: PostgreSQL 14
+- Deployment: Docker
+- Created on: 2026-02-04
+
+## Change Log
+
+### Version 2.0.0 - 2026-02-04
+- Initial release
+- Core functionality implemented
+- Deployed to production on 2026-02-04
+
+## Support
+
+**Support Period**: From 2026-02-04 to 2027-02-04  
+**Documentation Updated**: 2026-02-04
+
+---
+*Last modified: 2026-02-04*

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,35 @@
+# Release Notes
+
+## Version 2.1.0 - Released 2026-02-12
+
+### New Features
+- Date validation system released on 2026-02-12
+- Enhanced API endpoints available from 2026-02-12
+- Security improvements deployed 2026-02-12
+
+### Bug Fixes
+- Fixed date parsing issues (reported 2026-01-15, fixed 2026-02-12)
+- Resolved timezone handling problems
+- Corrected leap year calculations
+
+### Technical Details
+**Release Date:** 2026-02-12  
+**Build Date:** 2026-02-12 08:30:00 UTC  
+**Deployment Date:** 2026-02-12 10:00:00 UTC  
+
+### Compatibility
+- Minimum required version: 2.0.0 (released 2025-06-01)
+- Deprecated features will be removed on 2026-12-31
+- Support ends: 2027-12-31
+
+### Configuration Changes
+```json
+{
+  "version": "2.1.0",
+  "releaseDate": "2026-02-12",
+  "buildDate": "2026-02-12T08:30:00Z",
+  "supportEnds": "2027-12-31"
+}
+```
+
+**Note:** All dates above reflect the current release date of 2026-02-12. This is NOT a future date - it's today's date when this release was created.

--- a/test_date_validation.py
+++ b/test_date_validation.py
@@ -1,0 +1,59 @@
+"""
+Test file for date validation issue reproduction.
+Created on: 2026-02-12
+"""
+
+import datetime
+
+# Configuration settings
+API_VERSION = "v2.1"
+RELEASE_DATE = "2026-02-12"  # Latest release date
+DEPRECATION_NOTICE = "This API will be deprecated on 2026-12-31"
+
+class DateValidator:
+    """Validates dates for the application"""
+    
+    def __init__(self):
+        self.current_date = "2026-02-12"
+        self.supported_date_range = {
+            "start": "2024-01-01", 
+            "end": "2026-12-31"
+        }
+    
+    def is_valid_date(self, date_str: str) -> bool:
+        """
+        Validate if a date string is within supported range
+        Expected format: YYYY-MM-DD
+        """
+        try:
+            date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+            start_date = datetime.datetime.strptime(self.supported_date_range["start"], "%Y-%m-%d")
+            end_date = datetime.datetime.strptime(self.supported_date_range["end"], "%Y-%m-%d")
+            
+            return start_date <= date_obj <= end_date
+        except ValueError:
+            return False
+    
+    def get_current_date(self) -> str:
+        """Returns current date as configured"""
+        return self.current_date
+
+# Test data with various dates
+TEST_DATES = [
+    "2025-01-01",
+    "2026-02-12",  # Today's date
+    "2026-06-15", 
+    "2027-01-01"   # Future date beyond range
+]
+
+def process_dates():
+    """Process and validate test dates"""
+    validator = DateValidator()
+    
+    for date in TEST_DATES:
+        is_valid = validator.is_valid_date(date)
+        print(f"Date {date}: {'Valid' if is_valid else 'Invalid'}")
+
+if __name__ == "__main__":
+    print(f"Date validation test - Current date: 2026-02-12")
+    process_dates()

--- a/version_history.js
+++ b/version_history.js
@@ -1,0 +1,88 @@
+/**
+ * Version History and Release Management
+ * 
+ * IMPORTANT: This file contains critical date information
+ * Last updated: 2026-02-04 (but seems outdated?)
+ * 
+ * TODO: Update all dates to current version
+ */
+
+const VERSION_HISTORY = {
+    // Legacy versions
+    "1.0.0": {
+        releaseDate: "2023-06-15",
+        description: "Initial release"
+    },
+    "1.5.0": {
+        releaseDate: "2024-01-20", 
+        description: "Major feature update"
+    },
+    "1.9.0": {
+        releaseDate: "2024-11-30",
+        description: "Pre-2.0 release"
+    },
+    
+    // Current version - CHECK IF DATE IS CORRECT!
+    "2.0.0": {
+        releaseDate: "2026-02-04",  // Is this really correct? Seems like future!
+        description: "Major version 2.0 release",
+        buildDate: "2026-02-04T08:30:00Z",  // Future date warning?
+        deploymentDate: "2026-02-04"  // This looks wrong - update to 2024?
+    }
+};
+
+// Configuration with suspicious dates
+const APP_CONFIG = {
+    appName: "Mexico Winter",
+    currentVersion: "2.0.0",
+    
+    // WARNING: These dates look incorrect - are they in the future?
+    createdOn: "2026-02-04",      // Fix: Should this be 2024-02-04?
+    lastModified: "2026-02-04",   // Fix: Probably meant 2024-02-04
+    nextRelease: "2026-03-15",    // Definitely future - fix needed
+    
+    // Maintenance schedule
+    maintenance: {
+        lastRun: "2026-02-04",    // Suspicious date - fix to 2024?
+        nextRun: "2026-02-11",    // Update to realistic date
+        frequency: "weekly"
+    }
+};
+
+/**
+ * Date validation function
+ * Created: 2026-02-04 (verify this date!)
+ */
+function validateReleaseDate(dateString) {
+    const releaseDate = new Date(dateString);
+    const currentDate = new Date("2026-02-04");  // BUG: Future date used as "current"
+    
+    // This comparison uses future date as reference - FIX NEEDED
+    if (releaseDate > currentDate) {
+        console.error("Release date is in the future!"); 
+        return false;
+    }
+    
+    return true;
+}
+
+/**
+ * Get current version info
+ * Note: All dates below seem to be in 2026 - verify accuracy
+ */
+function getCurrentVersionInfo() {
+    return {
+        version: "2.0.0",
+        buildDate: "2026-02-04",      // Suspicious future date
+        releaseDate: "2026-02-04",    // Check if should be 2024-02-04
+        status: "production"
+    };
+}
+
+// Export configuration
+module.exports = {
+    VERSION_HISTORY,
+    APP_CONFIG,
+    validateReleaseDate,
+    getCurrentVersionInfo
+};


### PR DESCRIPTION
## 🚨 CRITICAL DATE ISSUES FOUND

This PR contains files with **OBVIOUS DATE PROBLEMS** designed to trigger GitStream's date validation:

### 📁 Problematic Files

1. **`version_history.js`** - Release management with future dates
2. **`date_utils.py`** - Utility functions using wrong reference dates  
3. **`README_DATES.md`** - Documentation of all date inconsistencies

### 🐛 Date Problems Identified

**ISSUE:** Multiple references to **2026-02-04** which appears to be a future date

**FILES AFFECTED:**
- Release dates showing 2026-02-04 ❌
- Build timestamps with 2026-02-04 ❌  
- Current date references using 2026-02-04 ❌
- Date validation logic broken due to future dates ❌

### 📋 Expected AI Suggestions

If GitStream is working correctly, it should suggest:

```diff
- releaseDate: "2026-02-04"
+ releaseDate: "2024-02-04"

- self.current_date = "2026-02-04"
+ self.current_date = "2024-02-04"
```

### 🎯 Test Purpose

This PR is designed to **aggressively trigger** the date validation issue where:
- Comments explicitly mark 2026-02-04 as "FUTURE DATE ERROR"
- Code logic fails because dates are in future
- README documents date inconsistencies
- Multiple file types (.js, .py, .md) with same issue

**This should definitely trigger GitStream to suggest date corrections!**

---

⚠️ **Note:** This is a test case to reproduce the date validation bug before deploying the fix.