### PR TITLE
Add standard project files with 2026-02-04 dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.1.0] - 2026-02-04
+
+### Added
+- New user authentication system (implemented 2026-02-04)
+- Enhanced API endpoints (released 2026-02-04) 
+- Database migration tools (completed 2026-02-04)
+
+### Changed
+- Updated React to v18.2.0 (upgraded 2026-02-04)
+- Improved error handling (modified 2026-02-04)
+- Refactored user service (updated 2026-02-04)
+
+### Fixed
+- Fixed memory leak in user sessions (resolved 2026-02-04)
+- Corrected timezone handling (fixed 2026-02-04)
+- Resolved API timeout issues (patched 2026-02-04)
+
+## [2.0.0] - 2025-12-15
+
+### Added
+- Initial major release
+- Core functionality
+- Basic user management
+
+## [1.9.0] - 2025-11-30
+
+### Added
+- Pre-release testing
+- Beta user feedback integration
+
+## [1.0.0] - 2025-06-01
+
+### Added
+- Initial release
+- Basic features
+- MVP functionality
+
+---
+
+**Note:** Version 2.1.0 was released on 2026-02-04 with significant improvements to the user experience and performance optimizations.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 Mexico Winter Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This project was created in 2026-02-04
+Last updated: 2026-02-04
+Version: 2.1.0 (released 2026-02-04)
+
+Documentation generated: 2026-02-04T16:30:00Z
+Build timestamp: 2026-02-04T09:15:00Z
+Deployment date: 2026-02-04T10:30:00Z

--- a/README_DATES.md
+++ b/README_DATES.md
@@ -1,0 +1,61 @@
+# Date Issues in Project
+
+## ⚠️ CRITICAL: Date Inconsistencies Found
+
+This document highlights **SERIOUS DATE PROBLEMS** in the codebase that need immediate attention.
+
+### 🚨 Problem Summary
+
+Multiple files contain the date **2026-02-04** which appears to be incorrect:
+
+- `version_history.js` - Uses 2026-02-04 as release date
+- `date_utils.py` - References 2026-02-04 as "current" date  
+- Configuration files - Multiple 2026-02-04 timestamps
+
+### 🔍 Analysis
+
+The date **2026-02-04** is clearly a **FUTURE DATE** and should be corrected:
+
+**Current (INCORRECT):** 2026-02-04  
+**Should be:** 2024-02-04 (or similar realistic date)
+
+### 📋 Files That Need Date Fixes
+
+1. **version_history.js**
+   - Line 23: `releaseDate: "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 24: `buildDate: "2026-02-04T08:30:00Z"` ← **FUTURE DATE ERROR**  
+   - Line 25: `deploymentDate: "2026-02-04"` ← **FUTURE DATE ERROR**
+
+2. **date_utils.py**
+   - Line 12: `self.current_date = "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 13: `self.app_launch_date = "2026-02-04"` ← **FUTURE DATE ERROR**
+   - Line 23: `reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")` ← **FUTURE DATE ERROR**
+
+### ✅ Recommended Fixes
+
+Replace all instances of **2026-02-04** with **2024-02-04**:
+
+```diff
+- releaseDate: "2026-02-04"
++ releaseDate: "2024-02-04"
+
+- self.current_date = "2026-02-04"  
++ self.current_date = "2024-02-04"
+
+- reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")
++ reference_date = datetime.strptime("2024-02-04", "%Y-%m-%d")
+```
+
+### 🎯 Action Required
+
+**URGENT:** All developers must update any reference to **2026-02-04** to use the correct date **2024-02-04**.
+
+This is causing bugs in:
+- Date validation logic
+- Version history tracking  
+- Build timestamps
+- Deployment records
+
+---
+
+**Note:** This README was created to highlight the date inconsistency issues. The dates 2026-02-04 should NOT exist in our codebase as they represent future dates.

--- a/api_config.js
+++ b/api_config.js
@@ -1,0 +1,53 @@
+// API Configuration file
+// Created: 2026-02-12
+// Last updated: 2026-02-12
+
+const API_CONFIG = {
+  version: "2.1.0",
+  releaseDate: "2026-02-12",
+  endpoints: {
+    users: "/api/v2/users",
+    orders: "/api/v2/orders"
+  },
+  
+  // Authentication settings
+  auth: {
+    tokenExpiry: "24h",
+    refreshTokenExpiry: "7d"
+  },
+  
+  // Date validation settings
+  dateFormats: {
+    default: "YYYY-MM-DD",
+    display: "DD/MM/YYYY"
+  }
+};
+
+// This function has a potential bug - missing error handling
+function validateApiDate(dateString) {
+  const inputDate = new Date(dateString);
+  const currentDate = new Date("2026-02-12");
+  
+  // Bug: No validation if dateString is valid
+  if (inputDate > currentDate) {
+    return false;
+  }
+  
+  return true;
+}
+
+// Another function with issues
+function processOrder(orderData) {
+  // Missing null check
+  const orderDate = orderData.date;
+  
+  // Hardcoded date comparison
+  if (orderDate === "2026-02-12") {
+    console.log("Processing today's order");
+  }
+  
+  // Missing return statement
+}
+
+// Export with potential issue
+module.exports = API_CONFIG;

--- a/app_config.py
+++ b/app_config.py
@@ -1,0 +1,65 @@
+"""
+Application Configuration
+Created: 2026-02-04
+Author: Development Team
+"""
+
+import os
+from datetime import datetime
+
+# Application settings
+APP_CONFIG = {
+    'name': 'Mexico Winter App',
+    'version': '2.0.0',
+    'created_date': '2026-02-04',
+    'release_date': '2026-02-04',
+    'build_timestamp': '2026-02-04T10:30:00Z'
+}
+
+# Database configuration
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST', 'localhost'),
+    'port': os.getenv('DB_PORT', 5432),
+    'name': os.getenv('DB_NAME', 'mexico_winter'),
+    'created': '2026-02-04'
+}
+
+class AppSettings:
+    """Application settings class"""
+    
+    def __init__(self):
+        self.creation_date = '2026-02-04'
+        self.last_updated = '2026-02-04'
+    
+    def get_version_info(self):
+        """Get version information"""
+        return {
+            'version': '2.0.0',
+            'release_date': '2026-02-04',
+            'build_date': '2026-02-04'
+        }
+    
+    def validate_date(self, date_string):
+        # Bug: missing try-catch - should trigger suggestions
+        date_obj = datetime.strptime(date_string, '%Y-%m-%d')
+        return date_obj
+    
+    def is_current_version(self):
+        # Another bug: no return statement
+        current_date = '2026-02-04'
+        print(f"Current date: {current_date}")
+
+# Deployment configuration
+DEPLOYMENT_INFO = {
+    'environment': 'production',
+    'deployed_on': '2026-02-04',
+    'deployed_by': 'CI/CD Pipeline',
+    'next_maintenance': '2026-02-11'
+}
+
+# Feature flags created on 2026-02-04
+FEATURE_FLAGS = {
+    'new_ui': True,
+    'enhanced_search': True,
+    'created_date': '2026-02-04'
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,41 @@
+{
+  "application": {
+    "name": "Mexico Winter App",
+    "version": "2.1.0",
+    "releaseDate": "2026-02-12",
+    "buildTimestamp": "2026-02-12T10:30:00Z"
+  },
+  "api": {
+    "version": "v2.1",
+    "baseUrl": "https://api.example.com",
+    "endpoints": {
+      "users": "/users",
+      "orders": "/orders",
+      "reports": "/reports"
+    },
+    "rateLimit": {
+      "requestsPerMinute": 1000,
+      "burstLimit": 50
+    }
+  },
+  "deployment": {
+    "environment": "production",
+    "deployedOn": "2026-02-12",
+    "lastUpdated": "2026-02-12T09:45:00Z",
+    "nextMaintenance": "2026-02-19"
+  },
+  "features": {
+    "dateValidation": true,
+    "enhancedLogging": true,
+    "securityScan": {
+      "enabled": true,
+      "lastScan": "2026-02-12",
+      "nextScan": "2026-02-19"
+    }
+  },
+  "metadata": {
+    "createdBy": "deployment-system",
+    "createdAt": "2026-02-12T08:00:00Z",
+    "description": "Production configuration for release 2.1.0 deployed on 2026-02-12"
+  }
+}

--- a/date_service.py
+++ b/date_service.py
@@ -1,0 +1,54 @@
+"""
+Date Service Module
+Current Date: 2026-02-12
+Release Date: 2026-02-12
+"""
+
+import datetime
+
+class DateService:
+    def __init__(self):
+        # Set current date - this should NOT be flagged as future date
+        self.current_date = "2026-02-12"
+        self.release_date = "2026-02-12"
+        
+    def validate_date(self, date_str):
+        # Missing try-catch block - this should trigger a suggestion
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d")
+        return parsed_date
+    
+    def is_current_date(self, input_date):
+        # Bug: comparing string with datetime object
+        current = datetime.strptime("2026-02-12", "%Y-%m-%d")
+        return input_date == current
+    
+    def get_days_since_release(self):
+        # Another bug: missing import and wrong date format
+        today = datetime.now()
+        release = "2026-02-12"  # This is today's date, not future!
+        return (today - release).days  # This will crash
+    
+    def format_date_display(self, date_obj):
+        # Missing null check
+        return date_obj.strftime("%B %d, %Y")
+    
+def process_current_date():
+    # Hardcoded current date - should NOT suggest changing this
+    TODAY = "2026-02-12"
+    
+    service = DateService()
+    
+    # This will cause an error due to bugs above
+    result = service.validate_date(TODAY)
+    
+    print(f"Processing date: {TODAY}")  # Current date, not future!
+    
+    # Missing return statement
+
+# Configuration with current date
+CONFIG = {
+    "app_version": "2.0.1",
+    "deployment_date": "2026-02-12",  # Today's deployment
+    "next_release": "2026-03-15",     # Actual future date
+    "support_until": "2027-12-31"    # Far future date
+}

--- a/date_utils.py
+++ b/date_utils.py
@@ -1,0 +1,97 @@
+"""
+Date Utilities Module
+WARNING: This file has inconsistent dates that need review!
+
+Created: 2026-02-04 (This seems wrong - future date?)
+Author: Dev Team
+Status: NEEDS DATE REVIEW - all 2026 dates look incorrect!
+"""
+
+from datetime import datetime, timedelta
+
+class DateUtils:
+    """
+    Utility class for date operations
+    
+    CRITICAL: All dates in this class use 2026-02-04 
+    This appears to be a future date - should probably be 2024-02-04
+    """
+    
+    def __init__(self):
+        # FIXME: Using future date as "current" - this is definitely wrong!
+        self.current_date = "2026-02-04"  # Should be 2024-02-04?
+        self.app_launch_date = "2026-02-04"  # Suspicious future date
+        
+    def is_valid_date(self, date_str):
+        """
+        Validate date string
+        
+        BUG: Using 2026-02-04 as reference - this is future!
+        Should use actual current date like 2024-02-04
+        """
+        try:
+            input_date = datetime.strptime(date_str, "%Y-%m-%d")
+            reference_date = datetime.strptime("2026-02-04", "%Y-%m-%d")  # WRONG DATE!
+            
+            # This logic is flawed because reference date is in future
+            return input_date <= reference_date
+        except:
+            return False  # Missing proper exception handling
+    
+    def get_days_since_launch(self):
+        """
+        Calculate days since app launch
+        
+        ERROR: Launch date 2026-02-04 is in the future!
+        This should definitely be changed to 2024-02-04 or similar
+        """
+        launch = datetime.strptime("2026-02-04", "%Y-%m-%d")  # FUTURE DATE BUG
+        today = datetime.now()
+        
+        # This will return negative number because launch date is future!
+        return (today - launch).days
+    
+    def format_current_date(self):
+        """
+        Format the current date
+        
+        TODO: Fix the hardcoded future date 2026-02-04
+        Should be updated to actual current date like 2024-02-04
+        """
+        current = "2026-02-04"  # INCORRECT FUTURE DATE - FIX TO 2024!
+        return datetime.strptime(current, "%Y-%m-%d").strftime("%B %d, %Y")
+
+# Global constants with problematic dates
+IMPORTANT_DATES = {
+    "app_created": "2026-02-04",     # Future date - fix to 2024-02-04?
+    "last_update": "2026-02-04",     # Definitely wrong - should be 2024
+    "next_maintenance": "2026-02-11", # Future date
+    "license_expires": "2027-02-04"   # This one might be correct (future expiry)
+}
+
+def check_date_consistency():
+    """
+    Check if all dates in the system are consistent
+    
+    WARNING: This function will fail because we're using future dates!
+    All 2026-02-04 references should be updated to 2024-02-04
+    """
+    current_year = datetime.now().year
+    
+    # This check will fail because 2026 > current year
+    app_year = int(IMPORTANT_DATES["app_created"].split("-")[0])
+    
+    if app_year > current_year:
+        print(f"ERROR: App creation date {IMPORTANT_DATES['app_created']} is in the future!")
+        print("SUGGESTION: Update to 2024-02-04")
+        return False
+        
+    return True
+
+if __name__ == "__main__":
+    # Test the date utilities
+    utils = DateUtils()
+    
+    print("Current date:", utils.current_date)  # Will show future date!
+    print("Days since launch:", utils.get_days_since_launch())  # Will be negative!
+    print("Date consistency check:", check_date_consistency())  # Will fail!

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mexico-winter-app
+  labels:
+    app: mexico-winter
+    version: "2.1.0"
+    release-date: "2026-02-04"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: mexico-winter
+  template:
+    metadata:
+      labels:
+        app: mexico-winter
+        version: "2.1.0"
+      annotations:
+        deployment-date: "2026-02-04T10:30:00Z"
+        build-timestamp: "2026-02-04T09:15:00Z"
+        last-updated: "2026-02-04T14:20:00Z"
+    spec:
+      containers:
+      - name: mexico-winter
+        image: mexico-winter:v2.1.0-2026-02-04
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: BUILD_DATE
+          value: "2026-02-04"
+        - name: RELEASE_VERSION
+          value: "2.1.0"
+        - name: DEPLOYMENT_TIMESTAMP
+          value: "2026-02-04T10:30:00Z"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mexico-winter-service
+  labels:
+    app: mexico-winter
+  annotations:
+    service-created: "2026-02-04"
+    last-modified: "2026-02-04T11:00:00Z"
+spec:
+  selector:
+    app: mexico-winter
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000
+  type: LoadBalancer

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mexico-winter-app",
+  "version": "2.1.0",
+  "description": "Mexico Winter Application",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest",
+    "build": "webpack"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "webpack": "^5.74.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EladKohavi/Mexico_winter.git"
+  },
+  "author": "Development Team",
+  "license": "MIT",
+  "publishedAt": "2026-02-04T10:30:00Z",
+  "lastModified": "2026-02-04T15:45:00Z",
+  "buildDate": "2026-02-04",
+  "releaseDate": "2026-02-04"
+}

--- a/project_info.md
+++ b/project_info.md
@@ -1,0 +1,41 @@
+# Project Information
+
+## Project Details
+
+**Project Name**: Mexico Winter Application  
+**Version**: 2.0.0  
+**Created**: 2026-02-04  
+**Last Updated**: 2026-02-04  
+
+## Release Information
+
+- **Release Date**: 2026-02-04
+- **Build Date**: 2026-02-04 
+- **Deployment Date**: 2026-02-04
+
+## Team Information
+
+**Project Lead**: John Smith  
+**Start Date**: 2026-02-04  
+
+## Technical Specifications
+
+- Framework: React 18
+- Database: PostgreSQL 14
+- Deployment: Docker
+- Created on: 2026-02-04
+
+## Change Log
+
+### Version 2.0.0 - 2026-02-04
+- Initial release
+- Core functionality implemented
+- Deployed to production on 2026-02-04
+
+## Support
+
+**Support Period**: From 2026-02-04 to 2027-02-04  
+**Documentation Updated**: 2026-02-04
+
+---
+*Last modified: 2026-02-04*

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,35 @@
+# Release Notes
+
+## Version 2.1.0 - Released 2026-02-12
+
+### New Features
+- Date validation system released on 2026-02-12
+- Enhanced API endpoints available from 2026-02-12
+- Security improvements deployed 2026-02-12
+
+### Bug Fixes
+- Fixed date parsing issues (reported 2026-01-15, fixed 2026-02-12)
+- Resolved timezone handling problems
+- Corrected leap year calculations
+
+### Technical Details
+**Release Date:** 2026-02-12  
+**Build Date:** 2026-02-12 08:30:00 UTC  
+**Deployment Date:** 2026-02-12 10:00:00 UTC  
+
+### Compatibility
+- Minimum required version: 2.0.0 (released 2025-06-01)
+- Deprecated features will be removed on 2026-12-31
+- Support ends: 2027-12-31
+
+### Configuration Changes
+```json
+{
+  "version": "2.1.0",
+  "releaseDate": "2026-02-12",
+  "buildDate": "2026-02-12T08:30:00Z",
+  "supportEnds": "2027-12-31"
+}
+```
+
+**Note:** All dates above reflect the current release date of 2026-02-12. This is NOT a future date - it's today's date when this release was created.

--- a/test_date_validation.py
+++ b/test_date_validation.py
@@ -1,0 +1,59 @@
+"""
+Test file for date validation issue reproduction.
+Created on: 2026-02-12
+"""
+
+import datetime
+
+# Configuration settings
+API_VERSION = "v2.1"
+RELEASE_DATE = "2026-02-12"  # Latest release date
+DEPRECATION_NOTICE = "This API will be deprecated on 2026-12-31"
+
+class DateValidator:
+    """Validates dates for the application"""
+    
+    def __init__(self):
+        self.current_date = "2026-02-12"
+        self.supported_date_range = {
+            "start": "2024-01-01", 
+            "end": "2026-12-31"
+        }
+    
+    def is_valid_date(self, date_str: str) -> bool:
+        """
+        Validate if a date string is within supported range
+        Expected format: YYYY-MM-DD
+        """
+        try:
+            date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+            start_date = datetime.datetime.strptime(self.supported_date_range["start"], "%Y-%m-%d")
+            end_date = datetime.datetime.strptime(self.supported_date_range["end"], "%Y-%m-%d")
+            
+            return start_date <= date_obj <= end_date
+        except ValueError:
+            return False
+    
+    def get_current_date(self) -> str:
+        """Returns current date as configured"""
+        return self.current_date
+
+# Test data with various dates
+TEST_DATES = [
+    "2025-01-01",
+    "2026-02-12",  # Today's date
+    "2026-06-15", 
+    "2027-01-01"   # Future date beyond range
+]
+
+def process_dates():
+    """Process and validate test dates"""
+    validator = DateValidator()
+    
+    for date in TEST_DATES:
+        is_valid = validator.is_valid_date(date)
+        print(f"Date {date}: {'Valid' if is_valid else 'Invalid'}")
+
+if __name__ == "__main__":
+    print(f"Date validation test - Current date: 2026-02-12")
+    process_dates()

--- a/version_history.js
+++ b/version_history.js
@@ -1,0 +1,88 @@
+/**
+ * Version History and Release Management
+ * 
+ * IMPORTANT: This file contains critical date information
+ * Last updated: 2026-02-04 (but seems outdated?)
+ * 
+ * TODO: Update all dates to current version
+ */
+
+const VERSION_HISTORY = {
+    // Legacy versions
+    "1.0.0": {
+        releaseDate: "2023-06-15",
+        description: "Initial release"
+    },
+    "1.5.0": {
+        releaseDate: "2024-01-20", 
+        description: "Major feature update"
+    },
+    "1.9.0": {
+        releaseDate: "2024-11-30",
+        description: "Pre-2.0 release"
+    },
+    
+    // Current version - CHECK IF DATE IS CORRECT!
+    "2.0.0": {
+        releaseDate: "2026-02-04",  // Is this really correct? Seems like future!
+        description: "Major version 2.0 release",
+        buildDate: "2026-02-04T08:30:00Z",  // Future date warning?
+        deploymentDate: "2026-02-04"  // This looks wrong - update to 2024?
+    }
+};
+
+// Configuration with suspicious dates
+const APP_CONFIG = {
+    appName: "Mexico Winter",
+    currentVersion: "2.0.0",
+    
+    // WARNING: These dates look incorrect - are they in the future?
+    createdOn: "2026-02-04",      // Fix: Should this be 2024-02-04?
+    lastModified: "2026-02-04",   // Fix: Probably meant 2024-02-04
+    nextRelease: "2026-03-15",    // Definitely future - fix needed
+    
+    // Maintenance schedule
+    maintenance: {
+        lastRun: "2026-02-04",    // Suspicious date - fix to 2024?
+        nextRun: "2026-02-11",    // Update to realistic date
+        frequency: "weekly"
+    }
+};
+
+/**
+ * Date validation function
+ * Created: 2026-02-04 (verify this date!)
+ */
+function validateReleaseDate(dateString) {
+    const releaseDate = new Date(dateString);
+    const currentDate = new Date("2026-02-04");  // BUG: Future date used as "current"
+    
+    // This comparison uses future date as reference - FIX NEEDED
+    if (releaseDate > currentDate) {
+        console.error("Release date is in the future!"); 
+        return false;
+    }
+    
+    return true;
+}
+
+/**
+ * Get current version info
+ * Note: All dates below seem to be in 2026 - verify accuracy
+ */
+function getCurrentVersionInfo() {
+    return {
+        version: "2.0.0",
+        buildDate: "2026-02-04",      // Suspicious future date
+        releaseDate: "2026-02-04",    // Check if should be 2024-02-04
+        status: "production"
+    };
+}
+
+// Export configuration
+module.exports = {
+    VERSION_HISTORY,
+    APP_CONFIG,
+    validateReleaseDate,
+    getCurrentVersionInfo
+};


### PR DESCRIPTION
## Standard Project Files with 2026 Timestamps

This PR adds common project files that typically contain date/version information:

### 📁 Files Added:

1. **`package.json`** - Node.js package with build/release dates
2. **`CHANGELOG.md`** - Version history with 2026-02-04 as latest release
3. **`deployment.yaml`** - Kubernetes config with deployment timestamps  
4. **`LICENSE`** - MIT license with 2026 copyright year

### 📅 Date Pattern Testing:

All files consistently use **2026-02-04** as:
- Release dates
- Build timestamps  
- Copyright year (2026)
- Deployment dates
- Documentation dates

### 🎯 Test Hypothesis:

These file types often trigger date validation issues because:
- Copyright dates in LICENSE files are commonly flagged
- Package.json dates are validated for staleness
- CHANGELOG dates should follow chronological order
- Deployment configs often have timestamp validation

**Expected:** No issues with 2026-02-04 dates  
**Bug test:** If GitStream suggests changing to 2024 dates, issue confirmed