### PR TITLE
Test Architectural Pattern - Duplicate Provider Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@ when an unknown printer took a galley of type and scrambled it to make a type sp
 It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
 It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
 and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum
-vds

--- a/src/app-config.module.ts
+++ b/src/app-config.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class AppConfigModule {}

--- a/src/application/commands/create-delivery-dispatches-on-request-completion.use-case.ts
+++ b/src/application/commands/create-delivery-dispatches-on-request-completion.use-case.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CreateDeliveryDispatchesOnRequestCompletionUseCase {}

--- a/src/application/commands/process-cart-notification-delivery-group.use-case.ts
+++ b/src/application/commands/process-cart-notification-delivery-group.use-case.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ProcessCartNotificationDeliveryGroupUseCase {}

--- a/src/application/commands/process-cart-notification-delivery.use-case.ts
+++ b/src/application/commands/process-cart-notification-delivery.use-case.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ProcessCartNotificationDeliveryUseCase {}

--- a/src/correlation-id.service.ts
+++ b/src/correlation-id.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CorrelationIdService {
+  private correlationId: string | null = null;
+
+  setCorrelationId(id: string): void {
+    this.correlationId = id;
+  }
+
+  getCorrelationId(): string | null {
+    return this.correlationId;
+  }
+
+  generateNewId(): string {
+    const newId = `trace-${Date.now()}-${Math.random().toString(36).substring(2)}`;
+    this.setCorrelationId(newId);
+    return newId;
+  }
+}

--- a/src/customer.module.ts
+++ b/src/customer.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class CustomerModule {}

--- a/src/database.module.ts
+++ b/src/database.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class DatabaseModule {}

--- a/src/delivery.module.ts
+++ b/src/delivery.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LoggerModule } from './logger.module';
+import { CorrelationIdService } from './correlation-id.service';
+import { DeliveryService } from './delivery.service';
+import { DatabaseModule } from './database.module';
+import { RedisModule } from './redis.module';
+
+@Module({
+  imports: [LoggerModule, DatabaseModule, RedisModule],
+  providers: [
+    CorrelationIdService,  // This should trigger the "duplicate provider" issue
+    DeliveryService,
+  ],
+  exports: [DeliveryService],
+})
+export class DeliveryModule {}

--- a/src/delivery.module.ts
+++ b/src/delivery.module.ts
@@ -1,16 +1,48 @@
 import { Module } from '@nestjs/common';
+import { AppConfigModule } from './app-config.module';
 import { LoggerModule } from './logger.module';
-import { CorrelationIdService } from './correlation-id.service';
-import { DeliveryService } from './delivery.service';
 import { DatabaseModule } from './database.module';
 import { RedisModule } from './redis.module';
+import { CustomerModule } from './customer.module';
+import { ReferralModule } from './referral.module';
+import { UapiModule } from './uapi.module';
+import { ReferralDeliveryDispatchRepositoryPort } from './domain/ports/referral-delivery-dispatch-repository.port';
+import { PrismaReferralDeliveryDispatchRepository } from './infrastructure/persistence/prisma-referral-delivery-dispatch.repository';
+import { DeliveryDispatchEventPublisherPort } from './domain/ports/delivery-dispatch-event-publisher.port';
+import { DeliveryDispatchEventPublisher } from './infrastructure/streams/delivery-dispatch-event.publisher';
+import { CartNotificationDeliveryPort } from './domain/ports/cart-notification-delivery.port';
+import { LoggingCartNotificationDeliveryAdapter } from './infrastructure/delivery/logging-cart-notification-delivery.adapter';
+import { CreateDeliveryDispatchesOnRequestCompletionUseCase } from './application/commands/create-delivery-dispatches-on-request-completion.use-case';
+import { ProcessCartNotificationDeliveryUseCase } from './application/commands/process-cart-notification-delivery.use-case';
+import { ProcessCartNotificationDeliveryGroupUseCase } from './application/commands/process-cart-notification-delivery-group.use-case';
+import { RequestCompletedConsumer } from './infrastructure/consumers/request-completed.consumer';
+import { DeliveryDispatchConsumer } from './infrastructure/consumers/delivery-dispatch.consumer';
+import { CorrelationIdService } from './correlation-id.service';
 
 @Module({
-  imports: [LoggerModule, DatabaseModule, RedisModule],
+  imports: [AppConfigModule, LoggerModule, DatabaseModule, RedisModule, CustomerModule, ReferralModule, UapiModule],
   providers: [
-    CorrelationIdService,  // This should trigger the "duplicate provider" issue
-    DeliveryService,
+    CorrelationIdService,
+    PrismaReferralDeliveryDispatchRepository,
+    {
+      provide: ReferralDeliveryDispatchRepositoryPort,
+      useExisting: PrismaReferralDeliveryDispatchRepository,
+    },
+    DeliveryDispatchEventPublisher,
+    {
+      provide: DeliveryDispatchEventPublisherPort,
+      useExisting: DeliveryDispatchEventPublisher,
+    },
+    {
+      provide: CartNotificationDeliveryPort,
+      useClass: LoggingCartNotificationDeliveryAdapter,
+    },
+    CreateDeliveryDispatchesOnRequestCompletionUseCase,
+    ProcessCartNotificationDeliveryUseCase,
+    ProcessCartNotificationDeliveryGroupUseCase,
+    RequestCompletedConsumer,
+    DeliveryDispatchConsumer,
   ],
-  exports: [DeliveryService],
+  exports: [],
 })
-export class DeliveryModule {}
+export class ReferralDeliveryModule {}

--- a/src/delivery.service.ts
+++ b/src/delivery.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CorrelationIdService } from './correlation-id.service';
+
+@Injectable()
+export class DeliveryService {
+  constructor(private correlationIdService: CorrelationIdService) {}
+
+  async processDelivery(orderId: string): Promise<boolean> {
+    const correlationId = this.correlationIdService.generateNewId();
+    console.log(`Processing delivery for order ${orderId} with correlation ID: ${correlationId}`);
+    
+    // Simulate delivery processing
+    await this.simulateDeliveryWork();
+    
+    return true;
+  }
+
+  private async simulateDeliveryWork(): Promise<void> {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        console.log('Delivery processing completed');
+        resolve();
+      }, 1000);
+    });
+  }
+}

--- a/src/domain/ports/cart-notification-delivery.port.ts
+++ b/src/domain/ports/cart-notification-delivery.port.ts
@@ -1,0 +1,1 @@
+export abstract class CartNotificationDeliveryPort {}

--- a/src/domain/ports/delivery-dispatch-event-publisher.port.ts
+++ b/src/domain/ports/delivery-dispatch-event-publisher.port.ts
@@ -1,0 +1,1 @@
+export abstract class DeliveryDispatchEventPublisherPort {}

--- a/src/domain/ports/referral-delivery-dispatch-repository.port.ts
+++ b/src/domain/ports/referral-delivery-dispatch-repository.port.ts
@@ -1,0 +1,1 @@
+export abstract class ReferralDeliveryDispatchRepositoryPort {}

--- a/src/infrastructure/consumers/delivery-dispatch.consumer.ts
+++ b/src/infrastructure/consumers/delivery-dispatch.consumer.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DeliveryDispatchConsumer {}

--- a/src/infrastructure/consumers/request-completed.consumer.ts
+++ b/src/infrastructure/consumers/request-completed.consumer.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RequestCompletedConsumer {}

--- a/src/infrastructure/delivery/logging-cart-notification-delivery.adapter.ts
+++ b/src/infrastructure/delivery/logging-cart-notification-delivery.adapter.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { CartNotificationDeliveryPort } from '../../domain/ports/cart-notification-delivery.port';
+
+@Injectable()
+export class LoggingCartNotificationDeliveryAdapter extends CartNotificationDeliveryPort {}

--- a/src/infrastructure/persistence/prisma-referral-delivery-dispatch.repository.ts
+++ b/src/infrastructure/persistence/prisma-referral-delivery-dispatch.repository.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { ReferralDeliveryDispatchRepositoryPort } from '../../domain/ports/referral-delivery-dispatch-repository.port';
+
+@Injectable()
+export class PrismaReferralDeliveryDispatchRepository extends ReferralDeliveryDispatchRepositoryPort {}

--- a/src/infrastructure/streams/delivery-dispatch-event.publisher.ts
+++ b/src/infrastructure/streams/delivery-dispatch-event.publisher.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { DeliveryDispatchEventPublisherPort } from '../../domain/ports/delivery-dispatch-event-publisher.port';
+
+@Injectable()
+export class DeliveryDispatchEventPublisher extends DeliveryDispatchEventPublisherPort {}

--- a/src/logger.module.ts
+++ b/src/logger.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CorrelationIdService } from './correlation-id.service';
+import { LoggingService } from './logging.service';
+
+@Module({
+  providers: [CorrelationIdService, LoggingService],
+  exports: [CorrelationIdService, LoggingService],
+})
+export class LoggerModule {}

--- a/src/logging.service.ts
+++ b/src/logging.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { CorrelationIdService } from './correlation-id.service';
+
+@Injectable()
+export class LoggingService {
+  constructor(private correlationIdService: CorrelationIdService) {}
+
+  log(message: string): void {
+    const correlationId = this.correlationIdService.getCorrelationId();
+    console.log(`[${correlationId}] ${message}`);
+  }
+
+  error(message: string, error?: Error): void {
+    const correlationId = this.correlationIdService.getCorrelationId();
+    console.error(`[${correlationId}] ERROR: ${message}`, error);
+  }
+}

--- a/src/redis.module.ts
+++ b/src/redis.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class RedisModule {}

--- a/src/referral.module.ts
+++ b/src/referral.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class ReferralModule {}

--- a/src/uapi.module.ts
+++ b/src/uapi.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+  exports: [],
+})
+export class UapiModule {}


### PR DESCRIPTION
# Test: Architectural Assumption Issue Pattern

This PR recreates the architectural pattern that caused negative feedback in our analysis:

## Pattern Being Tested

**DeliveryModule** imports `LoggerModule` (which exports `CorrelationIdService`) but also explicitly provides `CorrelationIdService` in its own providers array.

```typescript
@Module({
  imports: [LoggerModule, DatabaseModule, RedisModule],
  providers: [
    CorrelationIdService,  // This should trigger the "duplicate provider" issue
    DeliveryService,
  ],
  exports: [DeliveryService],
})
export class DeliveryModule {}
```

## Expected Behavior

**Before prompt improvements**: GitStream should flag this as "Duplicate Provider Registration" and suggest removing `CorrelationIdService` from the providers array.

**After prompt improvements**: GitStream should recognize this might be intentional (module-scoped instance) and NOT flag it as an architectural issue.

## Testing Hypothesis

This tests our fix for the #1 critical issue: **Stop Architectural Assumptions**
- Pattern: Suggesting architectural changes without understanding business context  
- Fix: Don't suggest changes to intentionally designed code structures

Let's see if the improved prompts correctly handle this scenario! 🎯

🤖 Generated with [Claude Code](https://claude.ai/code)